### PR TITLE
updated /app/lib/utils.ts for the dinonews_api

### DIFF
--- a/dinosaur_app/app/lib/utils.ts
+++ b/dinosaur_app/app/lib/utils.ts
@@ -20,15 +20,27 @@ export const convertDinoLocation = async (locationName: string) => {
     }  
 }
 
+const getPastDate = (pastDays: number) => {
+    const currentDate = new Date();
+    const pastDate = new Date(currentDate.getTime() - (pastDays * 24 * 60 * 60 * 1000));
+
+    const year = pastDate.getFullYear();
+    const month = `${(pastDate.getMonth() - 1)}`.padStart(2, '0');
+    const day = `${pastDate.getDate()}`.padStart(2, '0');
+
+    return `${year}-${month}-${day}`;
+}
+
 // fetch latest news from news api
 export const fetchLatestNews = async () => {
     try {
         const newsApiKey = process.env.NEWS_API_KEY
-        const url = `${process.env.NEWS_API_URL}${newsApiKey}`;
+        const fromDate = getPastDate(29)
+        const url = `https://newsapi.org/v2/everything?q=Dinosaur&from=${fromDate}&sortBy=popularity&apiKey=${newsApiKey}`;
         const response = await fetch(url);
 
         if (response.status === 200) {
-            const data = await response.json() as any;
+            const data = await response.json();
 
             // return the first ten news articles
             

--- a/dinosaur_app/app/ui/landing-page/footer-section/NewsItems.tsx
+++ b/dinosaur_app/app/ui/landing-page/footer-section/NewsItems.tsx
@@ -7,7 +7,7 @@ const NewsItems = async () => {
 
   return (
     <div className=" w-full flex flex-row gap-5 overflow-hidden hover:overflow-x-auto sm:px-5">
-      {availableNews.map((news: any) => (
+      {availableNews?.map((news: any) => (
         <div
           key={news.urlToImage}
           className="w-[300px] max-sm:w-[200px] h-[200px] max-sm:h-[150px] rounded-md bg-white shrink-0 z-0 relative hover:border border-orange-400"


### PR DESCRIPTION
 1. moved the url related to news_api from the .env.local into fetchLatestNews() function;
 2. added a function getPastDate() used to calculate the past 29 days. This is important as news api free tier only allows news from 30 days ago.
 3. modified the NewsItem component( by adding a optional chaining), to skip render if there is null data from the function fetchLatestNews()